### PR TITLE
feat: add control center launcher

### DIFF
--- a/V10/QUICKSTART.md
+++ b/V10/QUICKSTART.md
@@ -7,63 +7,50 @@
 ## 1. Preparar el entorno
 
 ```bash
-cd V10
 python -m venv .venv        # opcional
-source .venv/bin/activate    # en Windows: .venv\\Scripts\\activate
+source .venv/bin/activate    # en Windows: .venv\Scripts\activate
+pip install -r requirements.txt
 ```
-
-No hay dependencias adicionales, el proyecto usa únicamente la librería estándar de Python.
 
 ---
 
-## 2. Ejecutar el pipeline
+## 2. Lanzar todo desde el Centro de Control
 
 ```bash
-python -m V10.main "Build a customer onboarding portal"
+python control_center.py "Build a customer onboarding portal" --open-browser
 ```
 
-El comando lanza automáticamente el Product Manager en segundo plano, genera el proyecto y devuelve un JSON con los resultados del pipeline.
+Este comando:
+
+1. Arranca el servicio web local de Claude.
+2. Abre la interfaz web para responder prompts manualmente.
+3. Inicia el orquestador y muestra en vivo los mensajes entre agentes en la misma terminal.
 
 Parámetros útiles:
 
-- `--project-name portal_onboarding` → fuerza el nombre del proyecto.
-- `--workspace /tmp/v10` → cambia la carpeta donde se generan los archivos.
-- `--pm-timeout 120` → amplía el tiempo máximo de espera del PM Agent.
+- `--project-name portal_onboarding` → fuerza el nombre del proyecto generado.
+- `--workspace /tmp/v10` → cambia la carpeta base de proyectos y reportes.
+- `--skip-service` → usa un servicio Claude que ya esté corriendo en otro terminal.
+- `--iterations 5` → ajusta las vueltas máximas del feedback loop.
+
+Durante la ejecución responde los prompts desde `http://localhost:5000` copiando/pegando las respuestas de tu cuenta de Claude.
 
 ---
 
 ## 3. Revisar resultados
 
-- Código generado: `V10/runtime/workspace/<nombre-proyecto>/`
+- Código generado: `V10/runtime/projects/<session>/<slug>/`
 - Reporte JSON: `V10/runtime/reports/report_YYYYMMDD_HHMMSS.json`
 - Logs estructurados: `V10/runtime/logs/<agente>/<fecha>.log`
 
-Ejemplo de reporte parcial:
-
-```json
-{
-  "status": "PARTIAL_SUCCESS",
-  "decision": "REVIEW_REQUIRED",
-  "combined_score": 7.5,
-  "stages": {
-    "pm": {"modules": 6, "status": "SUCCESS"},
-    "dev": {"status": "SUCCESS", "files_count": 9},
-    "security": {"status": "PASS", "score": 8.0},
-    "qa": {"status": "FAIL", "score": 7.0}
-  }
-}
-```
+Al finalizar, el centro de control imprime el JSON completo con métricas, rutas y estado de cada etapa.
 
 ---
 
-## 4. ¿Y si quiero depurar?
+## 4. Modo avanzado
 
-```bash
-python -m V10.main "Test debug" --no-worker
-```
-
-Con `--no-worker` puedes lanzar el orquestador sin iniciar el PM automático. En ese modo podrías desarrollar tu propio consumidor de mensajes leyendo los archivos en `V10/runtime/agents/pm/inbox/`.
+¿Necesitas integrar la plataforma en tus propias herramientas? Puedes importar `OrchestratorV10Async` o `FileMessageBus` desde `V10.core` y reutilizar la arquitectura multi-agente sin el centro de control.
 
 ---
 
-¡Listo! Ya cuentas con una herramienta autónoma para explorar arquitecturas y generar bases de código iniciales.
+¡Listo! Con un solo comando tienes a todos los agentes colaborando mientras observas cada interacción en tiempo real.

--- a/V10/agents/dev_agent_v10.py
+++ b/V10/agents/dev_agent_v10.py
@@ -1,670 +1,377 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Dev Agent V10 - Developer con generación de código
-===================================================
+"""Dev Agent V10 - Genera código usando un servicio LLM local."""
 
-Responsabilidades:
-- Leer arquitectura propuesta por PM
-- Generar código Python completo
-- Validar sintaxis con ast.parse()
-- Crear estructura de proyecto
-- Escribir todos los archivos
-
-Modo Híbrido:
-- Lee arquitectura de filesystem
-- En producción: Espera que Claude (otro terminal) genere código
-- En test: Usa templates simples
-"""
-
-import sys
+from __future__ import annotations
 
 import ast
 import json
+import threading
 from pathlib import Path
-from datetime import datetime
-from typing import Optional, Dict, Any, List
+from typing import Dict, List, Optional, Sequence
 
-# Imports de infraestructura V10
-from V10.utils import create_logger
-from V10.protocols import Architecture, Implementation
+import requests
+
+from V10.core.message_bus import FileMessageBus
+from V10.utils import create_logger, ensure_directory, get_runtime_root
 
 
 class DevAgentV10:
-    """
-    Developer Agent V10 - Genera código basado en arquitectura.
+    """Agente de desarrollo que solicita código al servicio LLM local."""
 
-    Responsabilidades:
-    1. Leer arquitectura del PM
-    2. Generar código Python para cada módulo
-    3. Validar sintaxis
-    4. Crear estructura de proyecto
-    5. Escribir archivos
-    """
+    AGENT_NAME = "dev_agent"
 
-    def __init__(self, workspace_dir: str = "workspace"):
-        """
-        Inicializa Dev Agent V10.
+    def __init__(
+        self,
+        message_bus: FileMessageBus,
+        llm_endpoint: str = "http://localhost:5000/generate",
+    ) -> None:
+        self.message_bus = message_bus
+        self.llm_endpoint = llm_endpoint
+        self.logger = create_logger("DEV_AGENT")
+        self.project_root = ensure_directory(get_runtime_root() / "projects")
+        self.running = False
+        self.thread: Optional[threading.Thread] = None
+        self.projects: Dict[str, Dict[str, object]] = {}
 
-        Args:
-            workspace_dir: Directorio donde crear proyectos
-        """
-        self.logger = create_logger("DEV_AGENT_V10")
-        self.workspace = Path(workspace_dir)
-        self.workspace.mkdir(parents=True, exist_ok=True)
+    # ------------------------------------------------------------------
+    # Ciclo de vida
+    # ------------------------------------------------------------------
+    def start(self) -> threading.Thread:
+        if self.thread and self.thread.is_alive():
+            return self.thread
+        self.running = True
+        self.thread = threading.Thread(target=self.run, name="DevAgentV10", daemon=True)
+        self.thread.start()
+        self.logger.set_state("RUNNING")
+        return self.thread
 
-        self.logger.set_state("INITIALIZED")
-        self.logger.info("Dev Agent V10 initialized")
-        self.logger.info(f"Workspace: {self.workspace.absolute()}")
+    def stop(self) -> None:
+        self.running = False
+        if self.thread:
+            self.thread.join(timeout=2)
+            self.logger.info("Dev agent detenido")
 
-    def generate_project(self, architecture: Architecture, project_name: str = None) -> Optional[Implementation]:
-        """
-        Genera proyecto completo basado en arquitectura.
+    # ------------------------------------------------------------------
+    # Bucle principal
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        while self.running:
+            message = self.message_bus.receive(self.AGENT_NAME, timeout=1.0)
+            if message is None:
+                continue
 
-        Args:
-            architecture: Arquitectura propuesta por PM
-            project_name: Nombre del proyecto (auto-generado si None)
+            payload = message.payload
+            action = payload.get("action")
 
-        Returns:
-            Implementation object si exitoso, None si falla
-        """
-        self.logger.set_state("GENERATING")
-        start_time = datetime.now()
+            if action == "fix_security":
+                fixed = self._handle_security_fix(payload)
+                self._reply(message, {"fixed": fixed})
+                continue
 
-        # Crear directorio de proyecto
-        if not project_name:
-            project_name = f"project_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            if action == "improve_quality":
+                improved = self._handle_quality_improvement(payload)
+                self._reply(message, {"improved": improved})
+                continue
 
-        project_dir = self.workspace / project_name
-        self.logger.set_task(f"Generating project: {project_name}")
+            self.logger.info("Recibida especificación para generación de proyecto")
+            try:
+                project_path = payload.get("project_path")
+                project_dir = self._prepare_project_dir(project_path, payload.get("objective"))
+                spec = payload.get("spec", {})
+                generated_files = self._generate_modules(project_dir, spec)
+                extra_files = self._create_support_files(project_dir, spec)
+                all_files = generated_files + extra_files
 
-        try:
-            # Crear estructura de directorios
-            self._create_project_structure(project_dir)
-
-            # Generar código para cada módulo
-            files_created = []
-
-            # Generar módulos principales
-            for module in architecture.proposed_modules:
-                file_path = self._generate_module(
-                    project_dir,
-                    module,
-                    architecture
-                )
-                if file_path:
-                    files_created.append(str(file_path.relative_to(project_dir)))
-
-            # Generar archivos de configuración
-            config_files = self._generate_config_files(project_dir, architecture)
-            files_created.extend(config_files)
-
-            # Generar README
-            readme_path = self._generate_readme(project_dir, architecture)
-            if readme_path:
-                files_created.append(str(readme_path.relative_to(project_dir)))
-
-            # Generar requirements.txt
-            req_path = self._generate_requirements(project_dir, architecture)
-            if req_path:
-                files_created.append(str(req_path.relative_to(project_dir)))
-
-            duration = self.logger.measure_time("Project generation", start_time)
-
-            self.logger.success(
-                f"Project generated successfully",
-                {
-                    "project": project_name,
-                    "files_count": len(files_created),
-                    "duration": duration
+                self.projects[str(project_dir)] = {
+                    "spec": spec,
+                    "files": all_files,
                 }
-            )
 
-            self.logger.set_state("SUCCESS")
+                result_payload = {
+                    "status": "SUCCESS",
+                    "project_path": str(project_dir),
+                    "files": all_files,
+                    "spec": spec,
+                }
 
-            return Implementation(
-                project_dir=str(project_dir.absolute()),
-                files_created=files_created,
-                files_count=len(files_created),
-                technologies=architecture.technologies,
-                timestamp=datetime.now().isoformat()
-            )
+                self.message_bus.send(
+                    sender=self.AGENT_NAME,
+                    recipient="orchestrator",
+                    payload=result_payload,
+                    conversation_id=message.conversation_id,
+                    in_reply_to=message.message_id,
+                )
 
-        except Exception as e:
-            self.logger.error(
-                "Project generation failed",
-                {"error": str(e), "type": type(e).__name__}
-            )
-            self.logger.set_state("FAILED")
-            return None
+                # Disparar análisis de seguridad inicial
+                self.message_bus.send(
+                    sender=self.AGENT_NAME,
+                    recipient="security_agent",
+                    payload={
+                        "project_path": str(project_dir),
+                        "trigger": "initial",
+                    },
+                    conversation_id=message.conversation_id,
+                )
 
-    def _create_project_structure(self, project_dir: Path):
-        """Crea estructura de directorios del proyecto."""
-        self.logger.info(f"Creating project structure: {project_dir.name}")
+                self.logger.success("Proyecto generado", {"project_path": str(project_dir)})
+            except Exception as exc:
+                self.logger.error("Error generando proyecto", {"error": str(exc)})
+                failure_payload = {
+                    "status": "ERROR",
+                    "error": str(exc),
+                }
+                self.message_bus.send(
+                    sender=self.AGENT_NAME,
+                    recipient="orchestrator",
+                    payload=failure_payload,
+                    conversation_id=message.conversation_id,
+                    in_reply_to=message.message_id,
+                )
 
-        # Crear directorios principales
-        dirs = [
-            project_dir,
-            project_dir / "src",
-            project_dir / "tests",
-            project_dir / "docs",
-            project_dir / "config"
-        ]
+    # ------------------------------------------------------------------
+    # Generación de código
+    # ------------------------------------------------------------------
+    def _generate_modules(self, project_dir: Path, spec: Dict[str, object]) -> List[str]:
+        modules = spec.get("modules", [])
+        generated_files: List[str] = []
 
-        for dir_path in dirs:
-            dir_path.mkdir(parents=True, exist_ok=True)
+        for module_entry in modules:
+            module_spec = self._normalize_module(module_entry)
+            module_name = module_spec["name"]
+            code = self._generate_module_code(module_name, module_spec, spec)
+            file_path = self._write_module(project_dir, module_name, code)
+            generated_files.append(str(file_path.relative_to(project_dir)))
 
-        self.logger.success(f"Created {len(dirs)} directories")
+        return generated_files
 
-    def _generate_module(self, project_dir: Path, module_name: str, architecture: Architecture) -> Optional[Path]:
-        """
-        Genera código para un módulo.
+    def _generate_module_code(
+        self,
+        module_name: str,
+        module_spec: Dict[str, object],
+        project_spec: Dict[str, object],
+        extra_context: Optional[str] = None,
+    ) -> str:
+        """Genera código Python usando el servicio LLM local."""
 
-        En modo híbrido, esto sería reemplazado por código generado por Claude.
-        Por ahora, genera templates básicos.
-        """
-        self.logger.info(f"Generating module: {module_name}")
+        dependencies = project_spec.get("dependencies", [])
+        prompt = f"""Genera código Python profesional para este módulo:
 
-        # Determinar tipo de módulo por nombre
-        if "auth" in module_name.lower() or "jwt" in module_name.lower():
-            code = self._generate_auth_module(module_name, architecture)
-        elif "api" in module_name.lower() or "main" in module_name.lower():
-            code = self._generate_api_module(module_name, architecture)
-        elif "model" in module_name.lower() or "database" in module_name.lower():
-            code = self._generate_model_module(module_name, architecture)
-        elif "config" in module_name.lower():
-            code = self._generate_config_module(module_name, architecture)
-        else:
-            code = self._generate_generic_module(module_name, architecture)
+PROYECTO: {project_spec.get('project_type', 'Unknown')}
+ARQUITECTURA: {project_spec.get('architecture', 'N/A')}
 
-        # Validar sintaxis
+MÓDULO: {module_name}
+ESPECIFICACIONES DEL MÓDULO: {json.dumps(module_spec, indent=2, ensure_ascii=False)}
+DEPENDENCIAS DISPONIBLES: {', '.join(dependencies)}
+"""
+        if extra_context:
+            prompt += f"\nCONTEXTO ADICIONAL:\n{extra_context}\n"
+
+        prompt += """
+REQUERIMIENTOS ESTRICTOS:
+1. Incluye docstrings completos en español
+2. Usa type hints en todas las funciones
+3. Maneja errores con try/except apropiados
+4. Código listo para producción
+5. Sigue PEP 8
+6. Incluye logging donde sea relevante
+
+FORMATO DE SALIDA:
+- Genera SOLO código Python puro
+- Sin bloques markdown (```python)
+- Sin explicaciones adicionales
+- Código debe ser sintácticamente válido
+
+Genera el archivo {module_name}.py completo:
+"""
+
         try:
-            ast.parse(code)
-            self.logger.success(f"Module syntax validated: {module_name}")
-        except SyntaxError as e:
-            self.logger.error(
-                f"Syntax error in {module_name}",
-                {"error": str(e), "line": e.lineno}
+            response = requests.post(
+                self.llm_endpoint,
+                json={"prompt": prompt},
+                timeout=60,
             )
-            return None
+            response.raise_for_status()
+            result = response.json()
+            code = result["response"].strip()
+            code = self._clean_code_blocks(code)
+            self._validate_syntax(code)
+            self.logger.info("Código generado para módulo", {"module": module_name})
+            return code
+        except requests.RequestException as exc:
+            self.logger.error("Error conectando con servicio LLM", {"error": str(exc)})
+            return self._generate_fallback_code(module_name)
+        except (SyntaxError, ValueError) as exc:
+            self.logger.error("Código inválido generado por LLM", {"error": str(exc)})
+            return self._generate_fallback_code(module_name)
 
-        # Escribir archivo
-        file_path = project_dir / "src" / module_name
+    def _clean_code_blocks(self, code: str) -> str:
+        for marker in ("```python\n", "```python", "```", "``\n"):
+            code = code.replace(marker, "")
+        return code.strip()
+
+    def _validate_syntax(self, code: str) -> None:
+        ast.parse(code)
+
+    def _generate_fallback_code(self, module_name: str) -> str:
+        return f'''"""
+Módulo {module_name} - Generado en modo fallback.
+"""
+
+import logging
+
+
+def main() -> None:
+    """Función principal del módulo."""
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Módulo {module_name} - Servicio LLM no disponible")
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+    # ------------------------------------------------------------------
+    # Manejo de acciones correctivas
+    # ------------------------------------------------------------------
+    def _handle_security_fix(self, payload: Dict[str, object]) -> bool:
+        project_path = payload.get("project_path")
+        issues: Sequence[str] = payload.get("issues", [])  # type: ignore[assignment]
+        if not project_path or str(project_path) not in self.projects:
+            return False
+        spec = self.projects[str(project_path)].get("spec")
+        if not isinstance(spec, dict):
+            return False
+        targets = self._extract_targets_from_messages(issues)
+        context = "\n".join(f"- {issue}" for issue in issues)
+        return self._regenerate_modules(str(project_path), spec, targets, context)
+
+    def _handle_quality_improvement(self, payload: Dict[str, object]) -> bool:
+        project_path = payload.get("project_path")
+        suggestions: Sequence[str] = payload.get("suggestions", [])  # type: ignore[assignment]
+        if not project_path or str(project_path) not in self.projects:
+            return False
+        spec = self.projects[str(project_path)].get("spec")
+        if not isinstance(spec, dict):
+            return False
+        targets = self._extract_targets_from_messages(suggestions)
+        context = "\n".join(f"- {suggestion}" for suggestion in suggestions)
+        return self._regenerate_modules(str(project_path), spec, targets, context)
+
+    def _regenerate_modules(
+        self,
+        project_path: str,
+        spec: Dict[str, object],
+        targets: Sequence[str],
+        context: str,
+    ) -> bool:
+        project_dir = Path(project_path)
+        modules = spec.get("modules", [])
+        if not modules:
+            return False
+
+        normalized_targets = {target for target in targets if target}
+        if not normalized_targets:
+            normalized_targets = {self._normalize_module(entry)["name"] for entry in modules}
+
+        updated = False
+        for module_entry in modules:
+            module_spec = self._normalize_module(module_entry)
+            module_name = module_spec["name"]
+            if module_name not in normalized_targets:
+                continue
+            code = self._generate_module_code(module_name, module_spec, spec, extra_context=context)
+            file_path = self._write_module(project_dir, module_name, code)
+            updated = True
+            rel_path = str(file_path.relative_to(project_dir))
+            if project_path in self.projects:
+                files_obj = self.projects[project_path].get("files", [])
+                if isinstance(files_obj, list) and rel_path not in files_obj:
+                    files_obj.append(rel_path)
+
+        return updated
+
+    def _extract_targets_from_messages(self, messages: Sequence[str]) -> List[str]:
+        targets: List[str] = []
+        for message in messages:
+            if not message:
+                continue
+            parts = message.split()
+            for part in parts:
+                if part.endswith(".py"):
+                    targets.append(part.replace(".py", ""))
+        return targets
+
+    # ------------------------------------------------------------------
+    # Utilidades de escritura
+    # ------------------------------------------------------------------
+    def _write_module(self, project_dir: Path, module_name: str, code: str) -> Path:
+        file_name = module_name if module_name.endswith(".py") else f"{module_name}.py"
+        file_path = project_dir / file_name
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(file_path, "w", encoding="utf-8") as f:
-            f.write(code)
-
-        self.logger.success(f"Module written: {module_name}")
+        file_path.write_text(code, encoding="utf-8")
         return file_path
 
-    def _generate_auth_module(self, module_name: str, architecture: Architecture) -> str:
-        """Genera módulo de autenticación JWT."""
-        return '''#!/usr/bin/env python3
-"""
-Authentication module with JWT support.
-"""
-
-import os
-import jwt
-from datetime import datetime, timedelta
-from typing import Optional, Dict, Any
-
-
-SECRET_KEY = os.getenv("SECRET_KEY", "your-secret-key-change-in-production")
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
-
-
-def create_access_token(data: Dict[str, Any], expires_delta: Optional[timedelta] = None) -> str:
-    """
-    Create JWT access token.
-
-    Args:
-        data: Payload data
-        expires_delta: Token expiration time
-
-    Returns:
-        Encoded JWT token
-    """
-    to_encode = data.copy()
-
-    if expires_delta:
-        expire = datetime.utcnow() + expires_delta
-    else:
-        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-
-    to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
-
-    return encoded_jwt
-
-
-def verify_token(token: str) -> Optional[Dict[str, Any]]:
-    """
-    Verify and decode JWT token.
-
-    Args:
-        token: JWT token
-
-    Returns:
-        Decoded payload or None if invalid
-    """
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        return payload
-    except jwt.ExpiredSignatureError:
-        return None
-    except jwt.JWTError:
-        return None
-
-
-def hash_password(password: str) -> str:
-    """Hash password using bcrypt."""
-    import bcrypt
-    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
-
-
-def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """Verify password against hash."""
-    import bcrypt
-    return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
-'''
-
-    def _generate_api_module(self, module_name: str, architecture: Architecture) -> str:
-        """Genera módulo API principal."""
-        framework = architecture.technologies.get("framework", "FastAPI")
-
-        if "fastapi" in framework.lower():
-            return '''#!/usr/bin/env python3
-"""
-Main API module.
-"""
-
-from fastapi import FastAPI, HTTPException, Depends
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from typing import Optional
-
-
-app = FastAPI(
-    title="API",
-    description="Generated API with JWT authentication",
-    version="1.0.0"
-)
-
-security = HTTPBearer()
-
-
-@app.get("/")
-async def root():
-    """Root endpoint."""
-    return {"message": "API is running", "status": "ok"}
-
-
-@app.get("/health")
-async def health_check():
-    """Health check endpoint."""
-    return {"status": "healthy"}
-
-
-# Add your endpoints here
-'''
+    def _create_support_files(self, project_dir: Path, spec: Dict[str, object]) -> List[str]:
+        files: List[str] = []
+        requirements = project_dir / "requirements.txt"
+        dependencies = spec.get("dependencies", [])
+        if dependencies:
+            requirements.write_text("\n".join(sorted(set(dependencies))) + "\n", encoding="utf-8")
         else:
-            return '''#!/usr/bin/env python3
-"""
-Main API module.
-"""
+            requirements.write_text("requests\n", encoding="utf-8")
+        files.append(str(requirements.relative_to(project_dir)))
 
-def main():
-    """Main entry point."""
-    print("API starting...")
-    # Add your API logic here
-    pass
-
-
-if __name__ == "__main__":
-    main()
-'''
-
-    def _generate_model_module(self, module_name: str, architecture: Architecture) -> str:
-        """Genera módulo de modelos de base de datos."""
-        return '''#!/usr/bin/env python3
-"""
-Database models.
-"""
-
-from datetime import datetime
-from typing import Optional
-
-
-class BaseModel:
-    """Base model with common fields."""
-
-    def __init__(self):
-        self.id: Optional[int] = None
-        self.created_at: datetime = datetime.now()
-        self.updated_at: datetime = datetime.now()
-
-    def to_dict(self):
-        """Convert model to dictionary."""
-        return {
-            "id": self.id,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None
-        }
-
-
-# Add your models here
-'''
-
-    def _generate_config_module(self, module_name: str, architecture: Architecture) -> str:
-        """Genera módulo de configuración."""
-        return '''#!/usr/bin/env python3
-"""
-Configuration module.
-"""
-
-import os
-from typing import Any
-
-
-class Config:
-    """Application configuration."""
-
-    # Database
-    DATABASE_URL: str = os.getenv("DATABASE_URL", "sqlite:///./app.db")
-
-    # Security
-    SECRET_KEY: str = os.getenv("SECRET_KEY", "change-this-in-production")
-    ALGORITHM: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
-
-    # API
-    API_HOST: str = os.getenv("API_HOST", "0.0.0.0")
-    API_PORT: int = int(os.getenv("API_PORT", "8000"))
-    DEBUG: bool = os.getenv("DEBUG", "False").lower() == "true"
-
-    @classmethod
-    def get(cls, key: str, default: Any = None) -> Any:
-        """Get configuration value."""
-        return getattr(cls, key, default)
-
-
-config = Config()
-'''
-
-    def _generate_generic_module(self, module_name: str, architecture: Architecture) -> str:
-        """Genera módulo genérico."""
-        class_name = module_name.replace(".py", "").replace("_", " ").title().replace(" ", "")
-
-        return f'''#!/usr/bin/env python3
-"""
-{module_name} - Generated module.
-"""
-
-from typing import Optional, Dict, Any
-
-
-class {class_name}:
-    """
-    {class_name} class.
-
-    TODO: Implement functionality
-    """
-
-    def __init__(self):
-        """Initialize {class_name}."""
-        pass
-
-    def process(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Process data.
-
-        Args:
-            data: Input data
-
-        Returns:
-            Processed data
-        """
-        # TODO: Implement processing logic
-        return data
-
-
-def main():
-    """Main entry point."""
-    instance = {class_name}()
-    print(f"{{instance.__class__.__name__}} initialized")
-
-
-if __name__ == "__main__":
-    main()
-'''
-
-    def _generate_config_files(self, project_dir: Path, architecture: Architecture) -> List[str]:
-        """Genera archivos de configuración."""
-        files = []
-
-        # .env.example
-        env_example = project_dir / ".env.example"
-        with open(env_example, "w") as f:
-            f.write("""# Database
-DATABASE_URL=sqlite:///./app.db
-
-# Security
-SECRET_KEY=change-this-in-production
-ACCESS_TOKEN_EXPIRE_MINUTES=30
-
-# API
-API_HOST=0.0.0.0
-API_PORT=8000
-DEBUG=False
-""")
-        files.append(str(env_example.relative_to(project_dir)))
-
-        # .gitignore
-        gitignore = project_dir / ".gitignore"
-        with open(gitignore, "w") as f:
-            f.write("""__pycache__/
-*.py[cod]
-*$py.class
-.env
-.venv
-venv/
-*.db
-*.log
-.DS_Store
-""")
-        files.append(str(gitignore.relative_to(project_dir)))
-
+        readme = project_dir / "README.md"
+        readme_content = self._render_readme(spec)
+        readme.write_text(readme_content, encoding="utf-8")
+        files.append(str(readme.relative_to(project_dir)))
         return files
 
-    def _generate_readme(self, project_dir: Path, architecture: Architecture) -> Optional[Path]:
-        """Genera README.md."""
-        readme_path = project_dir / "README.md"
+    def _render_readme(self, spec: Dict[str, object]) -> str:
+        modules = spec.get("modules", [])
+        module_list = "\n".join(f"- {self._normalize_module(module)['name']}" for module in modules)
+        dependencies = spec.get("dependencies", [])
+        dependencies_list = "\n".join(f"- {dep}" for dep in dependencies)
+        return f"""# {spec.get('project_type', 'Proyecto generado')}
 
-        modules_list = "\n".join([f"- {m}" for m in architecture.proposed_modules])
-        tech_list = "\n".join([f"- **{k}**: {v}" for k, v in architecture.technologies.items()])
+## Arquitectura
+{spec.get('architecture', 'No especificada')}
 
-        content = f"""# {project_dir.name}
+## Flujo de Datos
+{spec.get('data_flow', 'No disponible')}
 
-Generated by Discovery Motor V10
+## Módulos
+{module_list or '- Sin módulos definidos'}
 
-## Architecture
-
-### Modules
-{modules_list}
-
-### Technologies
-{tech_list}
-
-## Analysis
-
-{architecture.analysis}
-
-## Setup
-
-1. Install dependencies:
-```bash
-pip install -r requirements.txt
-```
-
-2. Configure environment:
-```bash
-cp .env.example .env
-# Edit .env with your settings
-```
-
-3. Run the application:
-```bash
-python src/main_api.py
-```
-
-## Project Structure
-
-```
-{project_dir.name}/
-├── src/           # Source code
-├── tests/         # Test files
-├── docs/          # Documentation
-├── config/        # Configuration files
-└── README.md      # This file
-```
-
-## Development
-
-Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
+## Dependencias
+{dependencies_list or '- requests'}
 """
 
-        with open(readme_path, "w", encoding="utf-8") as f:
-            f.write(content)
+    def _prepare_project_dir(self, project_path: Optional[str], objective: Optional[str]) -> Path:
+        if project_path:
+            path = Path(project_path)
+            ensure_directory(path)
+            return path
+        slug = "_".join((objective or "proyecto").lower().split())
+        final_dir = self.project_root / slug
+        counter = 1
+        while final_dir.exists():
+            counter += 1
+            final_dir = self.project_root / f"{slug}_{counter}"
+        ensure_directory(final_dir)
+        return final_dir
 
-        return readme_path
+    def _normalize_module(self, module_entry: object) -> Dict[str, object]:
+        if isinstance(module_entry, dict) and "name" in module_entry:
+            return module_entry
+        if isinstance(module_entry, str):
+            return {"name": module_entry}
+        raise ValueError(f"Formato de módulo desconocido: {module_entry}")
 
-    def _generate_requirements(self, project_dir: Path, architecture: Architecture) -> Optional[Path]:
-        """Genera requirements.txt."""
-        req_path = project_dir / "requirements.txt"
-
-        framework = architecture.technologies.get("framework", "").lower()
-
-        requirements = []
-
-        if "fastapi" in framework:
-            requirements.extend([
-                "fastapi>=0.104.0",
-                "uvicorn[standard]>=0.24.0",
-                "pydantic>=2.5.0"
-            ])
-
-        if "jwt" in str(architecture.technologies).lower():
-            requirements.append("pyjwt>=2.8.0")
-            requirements.append("bcrypt>=4.1.0")
-
-        if "pytest" in str(architecture.technologies).lower():
-            requirements.append("pytest>=7.4.0")
-
-        # Agregar dependencias comunes
-        requirements.extend([
-            "python-dotenv>=1.0.0",
-            "requests>=2.31.0"
-        ])
-
-        with open(req_path, "w", encoding="utf-8") as f:
-            f.write("\n".join(sorted(set(requirements))) + "\n")
-
-        return req_path
-
-    def get_metrics(self) -> Dict[str, Any]:
-        """Retorna métricas del agente."""
-        return {
-            "dev_agent": self.logger.get_metrics(),
-            "workspace": str(self.workspace.absolute())
-        }
-
-
-def main():
-    """Test del Dev Agent V10."""
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Dev Agent V10 - Code Generation")
-    parser.add_argument(
-        "--test",
-        action="store_true",
-        help="Run test with sample architecture"
-    )
-    parser.add_argument(
-        "--architecture",
-        type=str,
-        help="Path to architecture JSON file"
-    )
-
-    args = parser.parse_args()
-
-    if args.test:
-        # Test con arquitectura de ejemplo
-        print("\n[TEST MODE] Using sample architecture\n")
-
-        sample_arch = Architecture(
-            proposed_modules=[
-                "auth_service.py",
-                "main_api.py",
-                "database_models.py",
-                "config.py"
-            ],
-            database_schema={
-                "users": {
-                    "id": "INTEGER PRIMARY KEY",
-                    "email": "TEXT UNIQUE NOT NULL",
-                    "password_hash": "TEXT NOT NULL"
-                }
-            },
-            technologies={
-                "framework": "FastAPI",
-                "database": "SQLite",
-                "auth": "JWT",
-                "testing": "pytest"
-            },
-            analysis="Simple REST API with JWT authentication",
-            reasoning="FastAPI provides automatic validation and documentation"
+    def _reply(self, message, payload: Dict[str, object]) -> None:
+        self.message_bus.send(
+            sender=self.AGENT_NAME,
+            recipient=message.sender,
+            payload=payload,
+            conversation_id=message.conversation_id,
+            in_reply_to=message.message_id,
         )
-
-        agent = DevAgentV10()
-        implementation = agent.generate_project(sample_arch, "test_project")
-
-        if implementation:
-            print("\n[SUCCESS] Project generated!\n")
-            print(f"Directory: {implementation.project_dir}")
-            print(f"Files: {implementation.files_count}")
-            print("\nFiles created:")
-            for file in implementation.files_created:
-                print(f"  - {file}")
-
-            agent.logger.print_summary()
-            sys.exit(0)
-        else:
-            print("\n[FAILED] Project generation failed")
-            agent.logger.print_summary()
-            sys.exit(1)
-
-    elif args.architecture:
-        # Cargar arquitectura desde archivo
-        with open(args.architecture, "r") as f:
-            arch_data = json.load(f)
-
-        architecture = Architecture(**arch_data)
-
-        agent = DevAgentV10()
-        implementation = agent.generate_project(architecture)
-
-        if implementation:
-            print(f"\n[SUCCESS] Project: {implementation.project_dir}\n")
-            sys.exit(0)
-        else:
-            print("\n[FAILED]\n")
-            sys.exit(1)
-
-    else:
-        parser.print_help()
-        sys.exit(1)
-
-
-if __name__ == "__main__":
-    main()

--- a/V10/agents/pm_agent_v10.py
+++ b/V10/agents/pm_agent_v10.py
@@ -1,209 +1,150 @@
-"""Product Manager agent for the autonomous V10 system."""
+"""PM Agent V10 - Analiza objetivos usando el servicio LLM local."""
 
 from __future__ import annotations
 
+import json
 import threading
-from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, Optional
+
+import requests
 
 from V10.core.message_bus import FileMessageBus
-from V10.protocols import Architecture
 from V10.utils import create_logger
 
 
-@dataclass
-class ArchitectureTemplate:
-    name: str
-    keywords: List[str]
-    modules: List[str]
-    technologies: Dict[str, str]
-
-
-TEMPLATES: List[ArchitectureTemplate] = [
-    ArchitectureTemplate(
-        name="web_api",
-        keywords=["api", "service", "backend", "rest", "graphql"],
-        modules=[
-            "main_api.py",
-            "auth_service.py",
-            "database_models.py",
-            "config.py",
-            "schemas.py",
-            "tests/test_api.py",
-        ],
-        technologies={
-            "framework": "FastAPI",
-            "database": "PostgreSQL",
-            "orm": "SQLAlchemy",
-            "auth": "JWT",
-            "testing": "pytest",
-            "documentation": "OpenAPI",
-        },
-    ),
-    ArchitectureTemplate(
-        name="data_pipeline",
-        keywords=["pipeline", "etl", "batch", "data"],
-        modules=[
-            "ingestion.py",
-            "transformations.py",
-            "orchestrator.py",
-            "storage.py",
-            "config.py",
-            "tests/test_pipeline.py",
-        ],
-        technologies={
-            "framework": "Prefect",
-            "database": "BigQuery",
-            "storage": "GCS",
-            "scheduler": "Prefect Cloud",
-            "testing": "pytest",
-            "monitoring": "Prometheus",
-        },
-    ),
-    ArchitectureTemplate(
-        name="analytics_dashboard",
-        keywords=["dashboard", "analytics", "insights", "report", "visualization"],
-        modules=[
-            "app.py",
-            "data_access.py",
-            "metrics.py",
-            "auth.py",
-            "config.py",
-            "tests/test_dashboard.py",
-        ],
-        technologies={
-            "framework": "Streamlit",
-            "database": "Snowflake",
-            "auth": "Auth0",
-            "testing": "pytest",
-            "monitoring": "Sentry",
-            "ci": "GitHub Actions",
-        },
-    ),
-]
-
-
 class PMAgentV10:
-    """Deterministic yet robust PM agent that generates architectures."""
+    """Agente de gestión de producto que delega el análisis a un LLM externo."""
 
-    def __init__(self) -> None:
+    AGENT_NAME = "pm_agent"
+
+    def __init__(
+        self,
+        message_bus: FileMessageBus,
+        llm_endpoint: str = "http://localhost:5000/analyze",
+    ) -> None:
+        self.message_bus = message_bus
+        self.llm_endpoint = llm_endpoint
         self.logger = create_logger("PM_AGENT")
-        self.logger.set_state("INITIALIZED")
-
-    def propose_architecture(self, objective: str) -> Architecture:
-        template = self._select_template(objective)
-        modules = list(dict.fromkeys(template.modules))
-        technologies = dict(template.technologies)
-        analysis = self._build_analysis(objective, template)
-        reasoning = self._build_reasoning(modules)
-        database_schema = self._build_schema(modules)
-        architecture = Architecture(
-            proposed_modules=modules,
-            database_schema=database_schema,
-            technologies=technologies,
-            analysis=analysis,
-            reasoning=reasoning,
-        )
-        self.logger.success("Architecture created", {
-            "modules": len(modules),
-            "template": template.name,
-        })
-        return architecture
+        self.running = False
+        self.thread: Optional[threading.Thread] = None
 
     # ------------------------------------------------------------------
-    # Template helpers
+    # Ciclo de vida
     # ------------------------------------------------------------------
-    def _select_template(self, objective: str) -> ArchitectureTemplate:
-        objective_lower = objective.lower()
-        for template in TEMPLATES:
-            if any(keyword in objective_lower for keyword in template.keywords):
-                self.logger.info("Selected template", {"template": template.name})
-                return template
-        self.logger.info("Falling back to web_api template")
-        return TEMPLATES[0]
+    def start(self) -> threading.Thread:
+        """Inicia el worker en un hilo independiente."""
 
-    def _build_analysis(self, objective: str, template: ArchitectureTemplate) -> str:
-        return (
-            f"The project '{objective}' is best served by the {template.name} template, "
-            f"which balances modularity and scalability. The proposed stack emphasises "
-            f"infrastructure-as-code, observability, and continuous delivery to ensure "
-            f"the system can evolve safely over time."
-        )
+        if self.thread and self.thread.is_alive():
+            return self.thread
+        self.running = True
+        self.thread = threading.Thread(target=self.run, name="PMAgentV10", daemon=True)
+        self.thread.start()
+        self.logger.set_state("RUNNING")
+        return self.thread
 
-    def _build_reasoning(self, modules: List[str]) -> str:
-        ordered = ", ".join(modules)
-        return (
-            f"The modules {ordered} follow a separation-of-concerns strategy: "
-            f"interface layers remain isolated from business logic and persistence. "
-            f"Each module is independently testable, enabling incremental delivery."
-        )
+    def stop(self) -> None:
+        """Detiene el worker y espera su finalización."""
 
-    def _build_schema(self, modules: List[str]) -> Dict[str, Dict[str, str]]:
-        schema: Dict[str, Dict[str, str]] = {
-            "users": {
-                "id": "UUID PRIMARY KEY",
-                "email": "TEXT UNIQUE NOT NULL",
-                "hashed_password": "TEXT NOT NULL",
-                "created_at": "TIMESTAMP NOT NULL",
-            },
-            "audit_logs": {
-                "id": "UUID PRIMARY KEY",
-                "user_id": "UUID REFERENCES users(id)",
-                "action": "TEXT NOT NULL",
-                "created_at": "TIMESTAMP NOT NULL",
-            },
-        }
-        if any("analytics" in module for module in modules):
-            schema["metrics"] = {
-                "id": "UUID PRIMARY KEY",
-                "name": "TEXT NOT NULL",
-                "value": "NUMERIC",
-                "recorded_at": "TIMESTAMP NOT NULL",
-            }
-        return schema
+        self.running = False
+        if self.thread:
+            self.thread.join(timeout=2)
+            self.logger.info("PM agent detenido")
 
+    # ------------------------------------------------------------------
+    # Bucle principal
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Worker principal que procesa mensajes del bus."""
 
-def start_pm_worker(bus: FileMessageBus, poll_interval: float = 0.5) -> threading.Event:
-    """Launch a background worker that processes PM messages."""
-
-    stop_event = threading.Event()
-
-    def _run() -> None:
-        agent = PMAgentV10()
-        agent.logger.set_state("WAITING")
-        while not stop_event.is_set():
-            try:
-                message = bus.receive("pm", timeout=poll_interval, poll_interval=poll_interval)
-            except Exception as exc:  # pragma: no cover - filesystem errors
-                agent.logger.error("Message bus error", {"error": str(exc)})
-                continue
+        while self.running:
+            message = self.message_bus.receive(self.AGENT_NAME, timeout=1.0)
             if message is None:
                 continue
-            agent.logger.set_state("PROCESSING")
+
             objective = message.payload.get("objective", "")
-            try:
-                architecture = agent.propose_architecture(objective)
-                response_payload = {
-                    "status": "SUCCESS",
-                    "architecture": architecture.to_dict(),
-                }
-            except Exception as exc:  # pragma: no cover - safety net
-                agent.logger.error("Failed to create architecture", {"error": str(exc)})
-                response_payload = {
-                    "status": "ERROR",
-                    "error": str(exc),
-                }
-            bus.send(
-                sender="pm",
+            project_path = message.payload.get("project_path")
+
+            self.logger.info("Analizando objetivo", {"objective": objective})
+            spec = self._analyze_objective_with_llm(objective)
+
+            response_payload = {
+                "status": "SUCCESS",
+                "objective": objective,
+                "spec": spec,
+            }
+            if project_path:
+                response_payload["project_path"] = project_path
+
+            # Respuesta al solicitante original (normalmente el orquestador)
+            self.message_bus.send(
+                sender=self.AGENT_NAME,
                 recipient=message.sender,
                 payload=response_payload,
                 conversation_id=message.conversation_id,
                 in_reply_to=message.message_id,
             )
-            agent.logger.set_state("WAITING")
-        agent.logger.info("PM worker stopped")
 
-    thread = threading.Thread(target=_run, name="pm-worker", daemon=True)
-    thread.start()
-    stop_event.thread = thread  # type: ignore[attr-defined]
-    return stop_event
+            # Enviar especificaciones al Dev Agent
+            dev_payload = {
+                "from": self.AGENT_NAME,
+                "objective": objective,
+                "spec": spec,
+            }
+            if project_path:
+                dev_payload["project_path"] = project_path
+
+            self.message_bus.send(
+                sender=self.AGENT_NAME,
+                recipient="dev_agent",
+                payload=dev_payload,
+                conversation_id=message.conversation_id,
+            )
+
+            self.logger.info("📤 Especificaciones enviadas a dev_agent")
+
+    # ------------------------------------------------------------------
+    # Lógica de negocio
+    # ------------------------------------------------------------------
+    def _analyze_objective_with_llm(self, objective: str) -> Dict:
+        """Analiza el objetivo usando el servicio LLM vía HTTP local."""
+
+        prompt = f"""Analiza este objetivo de proyecto y genera especificaciones técnicas:
+
+OBJETIVO: {objective}
+
+Genera un JSON estructurado con:
+- project_type: tipo de proyecto inferido (string)
+- modules: lista de módulos necesarios con nombres descriptivos (list)
+- dependencies: librerías Python requeridas (list)
+- architecture: descripción breve de arquitectura (string)
+- data_flow: flujo de datos entre componentes (string)
+
+IMPORTANTE: Responde ÚNICAMENTE con JSON válido, sin markdown ni explicaciones.
+"""
+
+        try:
+            response = requests.post(
+                self.llm_endpoint,
+                json={"prompt": prompt},
+                timeout=30,
+            )
+            response.raise_for_status()
+            result = response.json()
+            spec = json.loads(result["response"])
+            self.logger.success("Especificaciones generadas", {"objective": objective})
+            return spec
+        except (requests.RequestException, ValueError, json.JSONDecodeError) as exc:
+            self.logger.error("Error obteniendo especificaciones", {"error": str(exc)})
+            return self._fallback_spec(objective)
+
+    def _fallback_spec(self, objective: str) -> Dict:
+        """Fallback básico si el servicio LLM no está disponible."""
+
+        self.logger.warn("Usando especificaciones por defecto", {"objective": objective})
+        return {
+            "project_type": "generic_python_project",
+            "modules": ["main", "utils"],
+            "dependencies": ["requests"],
+            "architecture": "Arquitectura básica - Servicio LLM no disponible",
+            "data_flow": "main → utils",
+        }

--- a/V10/claude_service.py
+++ b/V10/claude_service.py
@@ -1,0 +1,146 @@
+"""
+Servicio HTTP local que expone Claude como endpoint.
+El usuario interactúa manualmente con esta interfaz web.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List
+
+from flask import Flask, Response, jsonify, render_template_string, request
+
+app = Flask(__name__)
+
+pending_prompts: List[Dict[str, object]] = []
+responses: Dict[int, str] = {}
+
+
+@app.route("/")
+def index() -> str:
+    """Renderiza la interfaz principal para gestionar prompts pendientes."""
+
+    html = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Claude Service - Discovery Motor V10</title>
+        <style>
+            body { font-family: Arial, sans-serif; margin: 20px; background: #1e1e1e; color: #ffffff; }
+            .prompt { background: #2d2d2d; padding: 20px; margin: 10px 0; border-radius: 8px; }
+            .prompt-id { color: #4CAF50; font-weight: bold; }
+            textarea { width: 100%; height: 200px; background: #1e1e1e; color: #ffffff;
+                       border: 1px solid #4CAF50; padding: 10px; font-family: monospace; }
+            button { background: #4CAF50; color: white; padding: 10px 20px;
+                     border: none; border-radius: 4px; cursor: pointer; }
+            button:hover { background: #45a049; }
+            .status { color: #ffa500; }
+            pre { background: #000000; padding: 10px; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; }
+        </style>
+    </head>
+    <body>
+        <h1>🤖 Claude Service - Discovery Motor V10</h1>
+        <p class="status">Prompts pendientes: {{ pending_count }}</p>
+
+        {% for prompt in prompts %}
+        <div class="prompt">
+            <div class="prompt-id">Prompt ID: {{ prompt.id }}</div>
+            <div><strong>Timestamp:</strong> {{ prompt.timestamp }}</div>
+            <div><strong>Tipo:</strong> {{ prompt.type }}</div>
+            <pre>{{ prompt.text }}</pre>
+
+            <form action="/respond/{{ prompt.id }}" method="post">
+                <textarea name="response" placeholder="Pega aquí la respuesta de Claude..."></textarea><br>
+                <button type="submit">Enviar Respuesta</button>
+            </form>
+        </div>
+        {% endfor %}
+
+        {% if pending_count == 0 %}
+        <p>✅ No hay prompts pendientes. El sistema está esperando...</p>
+        {% endif %}
+    </body>
+    </html>
+    """
+    return render_template_string(html, prompts=pending_prompts, pending_count=len(pending_prompts))
+
+
+@app.route("/health")
+def health() -> Response:
+    """Expone el estado del servicio para herramientas externas."""
+
+    return jsonify({"status": "ok", "pending_prompts": len(pending_prompts)})
+
+
+def _enqueue_prompt(prompt: str, prompt_type: str) -> Dict[str, object]:
+    prompt_id = len(pending_prompts) + 1
+    prompt_data = {
+        "id": prompt_id,
+        "type": prompt_type,
+        "text": prompt,
+        "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    }
+    pending_prompts.append(prompt_data)
+    return prompt_data
+
+
+def _wait_for_response(prompt_data: Dict[str, object], max_wait: int = 300) -> Dict[str, str]:
+    import time
+
+    prompt_id = prompt_data["id"]
+    waited = 0
+    while waited < max_wait:
+        if prompt_id in responses:
+            response = responses.pop(prompt_id)
+            pending_prompts.remove(prompt_data)
+            return {"response": response}
+        time.sleep(2)
+        waited += 2
+    return {"error": "Timeout esperando respuesta"}
+
+
+@app.route("/analyze", methods=["POST"])
+def analyze():
+    """Endpoint que utiliza el PM Agent para obtener especificaciones."""
+
+    data = request.json or {}
+    prompt = data.get("prompt", "")
+    prompt_data = _enqueue_prompt(prompt, "PM_ANALYSIS")
+    result = _wait_for_response(prompt_data)
+    status = 200 if "response" in result else 408
+    return jsonify(result), status
+
+
+@app.route("/generate", methods=["POST"])
+def generate():
+    """Endpoint que utiliza el Dev Agent para generar código."""
+
+    data = request.json or {}
+    prompt = data.get("prompt", "")
+    prompt_data = _enqueue_prompt(prompt, "CODE_GENERATION")
+    result = _wait_for_response(prompt_data)
+    status = 200 if "response" in result else 408
+    return jsonify(result), status
+
+
+@app.route("/respond/<int:prompt_id>", methods=["POST"])
+def respond(prompt_id: int) -> str:
+    """Permite al usuario registrar la respuesta manual de Claude."""
+
+    response_text = request.form.get("response", "")
+    responses[prompt_id] = response_text
+    return """
+    <html>
+    <body style="background: #1e1e1e; color: #ffffff; font-family: Arial, sans-serif;">
+        <h2>✅ Respuesta enviada!</h2>
+        <p>El agente recibirá tu respuesta.</p>
+        <a href="/" style="color: #4CAF50;">← Volver a prompts pendientes</a>
+    </body>
+    </html>
+    """
+
+
+if __name__ == "__main__":
+    print("🚀 Claude Service iniciado en http://localhost:5000")
+    print("📝 Abre el navegador para responder prompts del sistema")
+    app.run(host="0.0.0.0", port=5000, debug=False, use_reloader=False)

--- a/V10/core/feedback_loop.py
+++ b/V10/core/feedback_loop.py
@@ -1,0 +1,150 @@
+"""Feedback loop entre agentes para reforzar seguridad y calidad."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from V10.core.message_bus import FileMessageBus
+from V10.utils import create_logger
+
+
+class FeedbackLoop:
+    """Coordina iteraciones entre los agentes de seguridad, QA y desarrollo."""
+
+    def __init__(self, message_bus: FileMessageBus, max_iterations: int = 3) -> None:
+        self.bus = message_bus
+        self.max_iterations = max_iterations
+        self.logger = create_logger("FEEDBACK_LOOP")
+        self.last_security_payload: Dict[str, object] = {}
+        self.last_qa_payload: Dict[str, object] = {}
+
+    def iterate_until_pass(self, project_path: str) -> bool:
+        """Itera el código hasta que apruebe seguridad y QA."""
+
+        for iteration in range(1, self.max_iterations + 1):
+            self.logger.info(
+                "Iniciando iteración de feedback",
+                {"iteration": iteration, "max": self.max_iterations},
+            )
+
+            security_passed = self._run_security_cycle(project_path, iteration)
+            if not security_passed:
+                continue
+
+            qa_passed = self._run_qa_cycle(project_path, iteration)
+            if qa_passed:
+                self.logger.success("Código aprobado", {"iteration": iteration})
+                return True
+
+        self.logger.error(
+            "No se logró aprobar las validaciones",
+            {"iterations": self.max_iterations},
+        )
+        return False
+
+    # ------------------------------------------------------------------
+    # Ciclos específicos
+    # ------------------------------------------------------------------
+    def _run_security_cycle(self, project_path: str, iteration: int) -> bool:
+        message = self.bus.send(
+            sender="feedback_loop",
+            recipient="security_agent",
+            payload={
+                "project_path": project_path,
+                "iteration": iteration,
+            },
+        )
+        reply = self.bus.wait_for_reply(
+            agent_name="feedback_loop",
+            in_reply_to=message.message_id,
+            timeout=30.0,
+        )
+        if reply is None:
+            self.logger.error("Security agent no respondió")
+            return False
+
+        payload = reply.payload
+        self.last_security_payload = dict(payload)
+        issues: List[str] = payload.get("issues", [])
+        critical: List[str] = payload.get("critical_issues", [])
+        score = payload.get("score", 0.0)
+
+        if issues or critical:
+            total_issues = len(issues) + len(critical)
+            self.logger.warn(
+                "Problemas de seguridad detectados",
+                {"count": total_issues, "score": score},
+            )
+            fix_message = self.bus.send(
+                sender="feedback_loop",
+                recipient="dev_agent",
+                payload={
+                    "action": "fix_security",
+                    "project_path": project_path,
+                    "issues": issues + critical,
+                    "iteration": iteration,
+                },
+            )
+            fix_reply = self.bus.wait_for_reply(
+                agent_name="feedback_loop",
+                in_reply_to=fix_message.message_id,
+                timeout=60.0,
+            )
+            if not fix_reply or not fix_reply.payload.get("fixed"):
+                self.logger.warn("El Dev agent no pudo corregir los problemas de seguridad")
+                return False
+            return False  # Requiere nueva iteración tras aplicar fixes
+
+        self.logger.info("Seguridad aprobada", {"score": score})
+        return True
+
+    def _run_qa_cycle(self, project_path: str, iteration: int) -> bool:
+        message = self.bus.send(
+            sender="feedback_loop",
+            recipient="qa_agent",
+            payload={
+                "project_path": project_path,
+                "iteration": iteration,
+            },
+        )
+        reply = self.bus.wait_for_reply(
+            agent_name="feedback_loop",
+            in_reply_to=message.message_id,
+            timeout=30.0,
+        )
+        if reply is None:
+            self.logger.error("QA agent no respondió")
+            return False
+
+        payload = reply.payload
+        self.last_qa_payload = dict(payload)
+        score = payload.get("score", 0.0)
+        suggestions: List[str] = payload.get("suggestions", [])
+
+        if score < 0.7:
+            self.logger.warn(
+                "Score de calidad insuficiente",
+                {"score": score},
+            )
+            improve_message = self.bus.send(
+                sender="feedback_loop",
+                recipient="dev_agent",
+                payload={
+                    "action": "improve_quality",
+                    "project_path": project_path,
+                    "suggestions": suggestions,
+                    "iteration": iteration,
+                },
+            )
+            improve_reply = self.bus.wait_for_reply(
+                agent_name="feedback_loop",
+                in_reply_to=improve_message.message_id,
+                timeout=60.0,
+            )
+            if not improve_reply or not improve_reply.payload.get("improved"):
+                self.logger.warn("El Dev agent no pudo mejorar la calidad")
+                return False
+            return False
+
+        self.logger.info("QA aprobado", {"score": score})
+        return True

--- a/V10/core/message_bus.py
+++ b/V10/core/message_bus.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional, Any
 
-from V10.utils import create_logger, get_agent_runtime_dir, get_runtime_root
+from V10.utils import create_logger, ensure_directory, get_runtime_root
 
 
 @dataclass
@@ -40,8 +40,7 @@ class FileMessageBus:
         self.logger = create_logger("MESSAGE_BUS")
         if base_dir is None:
             base_dir = get_runtime_root() / "agents"
-        self.base_dir = Path(base_dir)
-        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.base_dir = ensure_directory(Path(base_dir))
 
     # ------------------------------------------------------------------
     # Public API
@@ -117,7 +116,6 @@ class FileMessageBus:
     # Internal helpers
     # ------------------------------------------------------------------
     def _inbox_dir(self, agent_name: str) -> Path:
-        agent_dir = get_agent_runtime_dir(agent_name)
-        inbox = agent_dir / "inbox"
-        inbox.mkdir(parents=True, exist_ok=True)
+        agent_dir = ensure_directory(self.base_dir / agent_name)
+        inbox = ensure_directory(agent_dir / "inbox")
         return inbox

--- a/V10/core/orchestrator_v10_async.py
+++ b/V10/core/orchestrator_v10_async.py
@@ -1,53 +1,75 @@
-"""Asynchronous orchestrator that coordinates all V10 agents."""
+"""Orquestador asíncrono que coordina los agentes V10 vía servicio LLM local."""
 
 from __future__ import annotations
 
 import json
+import threading
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import Any, Dict, Optional
 
 from V10.agents.dev_agent_v10 import DevAgentV10
-from V10.agents.pm_agent_v10 import start_pm_worker
+from V10.agents.pm_agent_v10 import PMAgentV10
 from V10.agents.qa_agent_v10 import QAAgentV10
 from V10.agents.security_agent_v10 import SecurityAgentV10
+from V10.core.feedback_loop import FeedbackLoop
 from V10.core.message_bus import FileMessageBus
-from V10.protocols import Architecture
-from V10.utils import create_logger, get_runtime_root
+from V10.utils import create_logger, ensure_directory, get_runtime_root
 
 
 @dataclass
 class OrchestratorSettings:
     workspace_dir: Path
-    use_pm_worker: bool = True
+    use_feedback_loop: bool = True
     pm_timeout: int = 60
-    min_security_score: float = 7.0
-    min_qa_score: float = 7.0
+    dev_timeout: int = 180
+    max_iterations: int = 3
 
 
 class OrchestratorV10Async:
-    """Coordinates PM, Dev, Security and QA agents through the file bus."""
+    """Coordina PM, Dev, Security y QA usando el bus de mensajes."""
 
     def __init__(self, settings: Optional[OrchestratorSettings] = None) -> None:
         runtime_root = get_runtime_root()
-        default_workspace = runtime_root / "workspace"
+        default_workspace = runtime_root / "projects"
         settings = settings or OrchestratorSettings(workspace_dir=default_workspace)
         self.settings = settings
+
         self.logger = create_logger("ORCHESTRATOR")
         self.logger.set_state("INITIALIZED")
 
-        self.bus = FileMessageBus()
-        self.dev_agent = DevAgentV10(workspace_dir=str(self.settings.workspace_dir))
-        self.security_agent = SecurityAgentV10()
-        self.qa_agent = QAAgentV10()
+        ensure_directory(self.settings.workspace_dir)
+        self.session_id = f"session_{datetime.now():%Y%m%d_%H%M%S}_{uuid.uuid4().hex[:6]}"
+        agents_dir = ensure_directory(get_runtime_root() / "agents" / self.session_id)
+        self.bus = FileMessageBus(base_dir=agents_dir)
+        self.workspace_root = ensure_directory(self.settings.workspace_dir / self.session_id)
 
-        self.pm_worker_stop = None
-        if self.settings.use_pm_worker:
-            self.pm_worker_stop = start_pm_worker(self.bus)
+        self.logger.info(
+            "Session initialized",
+            {
+                "session_id": self.session_id,
+                "agents_dir": str(agents_dir),
+                "workspace_root": str(self.workspace_root),
+            },
+        )
+
+        self.pm_agent = PMAgentV10(self.bus)
+        self.dev_agent = DevAgentV10(self.bus)
+        self.feedback_loop = FeedbackLoop(self.bus, max_iterations=self.settings.max_iterations)
+
+        self.stop_event = threading.Event()
+        self.security_thread = threading.Thread(target=self._security_worker, name="SecurityWorker", daemon=True)
+        self.qa_thread = threading.Thread(target=self._qa_worker, name="QAWorker", daemon=True)
+
+        self.pm_agent.start()
+        self.dev_agent.start()
+        self.security_thread.start()
+        self.qa_thread.start()
 
     # ------------------------------------------------------------------
-    # Public API
+    # API pública
     # ------------------------------------------------------------------
     def execute(self, objective: str, project_name: Optional[str] = None) -> Dict[str, Any]:
         self.logger.set_state("RUNNING")
@@ -57,47 +79,60 @@ class OrchestratorV10Async:
             "status": "running",
             "stages": {},
         }
+        result["session_id"] = self.session_id
+        result["workspace_root"] = str(self.workspace_root)
+
+        project_dir = self._prepare_project_dir(project_name or objective)
 
         try:
-            architecture = self._run_pm_stage(objective)
+            architecture_payload = self._request_architecture(objective, project_dir)
             result["stages"]["pm"] = {
                 "status": "SUCCESS",
-                "modules": len(architecture.proposed_modules),
-                "technologies": architecture.technologies,
+                "spec": architecture_payload.get("spec", {}),
             }
 
-            implementation = self.dev_agent.generate_project(architecture, project_name)
-            if implementation is None:
-                raise RuntimeError("Developer agent failed to create the project")
+            implementation_payload = self._wait_for_dev_completion()
+            if implementation_payload.get("status") != "SUCCESS":
+                raise RuntimeError(implementation_payload.get("error", "Dev agent error"))
+
+            project_path = implementation_payload.get("project_path", str(project_dir))
             result["stages"]["dev"] = {
                 "status": "SUCCESS",
-                "project_dir": implementation.project_dir,
-                "files_count": implementation.files_count,
+                "project_dir": project_path,
+                "files": implementation_payload.get("files", []),
             }
 
-            security_result = self.security_agent.analyze(implementation.project_dir)
+            if self.settings.use_feedback_loop:
+                feedback_passed = self.feedback_loop.iterate_until_pass(project_path)
+            else:
+                feedback_passed = True
+
+            security_payload = self._request_security_report(project_path)
+            qa_payload = self._request_qa_report(project_path)
+
             result["stages"]["security"] = {
-                "status": "PASS" if security_result.passed else "FAIL",
-                "score": security_result.score,
-                "critical_issues": security_result.critical_issues,
+                "status": "PASS" if security_payload.get("passed") else "FAIL",
+                "score": security_payload.get("score"),
+                "issues": security_payload.get("issues", []),
+                "critical_issues": security_payload.get("critical_issues", []),
             }
 
-            qa_result = self.qa_agent.analyze(implementation.project_dir)
             result["stages"]["qa"] = {
-                "status": "PASS" if qa_result.passed else "FAIL",
-                "score": qa_result.score,
-                "issues": qa_result.issues,
+                "status": "PASS" if qa_payload.get("passed") else "FAIL",
+                "score": qa_payload.get("score"),
+                "issues": qa_payload.get("issues", []),
+                "warnings": qa_payload.get("warnings", []),
             }
 
-            combined_score = (security_result.score + qa_result.score) / 2
-            gates_passed = (
-                security_result.score >= self.settings.min_security_score
-                and qa_result.score >= self.settings.min_qa_score
-                and not security_result.critical_issues
-            )
-            result["combined_score"] = round(combined_score, 1)
-            result["status"] = "SUCCESS" if gates_passed else "PARTIAL_SUCCESS"
-            result["decision"] = "APPROVED" if gates_passed else "REVIEW_REQUIRED"
+            combined_score = 0.0
+            if security_payload.get("score") is not None and qa_payload.get("score") is not None:
+                combined_score = (security_payload.get("score", 0.0) + qa_payload.get("score", 0.0)) / 2
+
+            result["combined_score"] = round(combined_score, 2)
+            gates_passed = security_payload.get("passed") and qa_payload.get("passed")
+            result["status"] = "SUCCESS" if gates_passed and feedback_passed else "REVIEW_REQUIRED"
+            result["decision"] = "APPROVED" if gates_passed and feedback_passed else "MANUAL_REVIEW"
+            result["project_path"] = project_path
 
             report_path = self._persist_report(result)
             result["report_path"] = str(report_path)
@@ -113,14 +148,14 @@ class OrchestratorV10Async:
         return result
 
     # ------------------------------------------------------------------
-    # Internal helpers
+    # Etapas internas
     # ------------------------------------------------------------------
-    def _run_pm_stage(self, objective: str) -> Architecture:
-        self.logger.info("Requesting architecture from PM agent")
+    def _request_architecture(self, objective: str, project_dir: Path) -> Dict[str, Any]:
+        self.logger.info("Solicitando especificaciones al PM agent")
         message = self.bus.send(
             sender="orchestrator",
-            recipient="pm",
-            payload={"objective": objective},
+            recipient="pm_agent",
+            payload={"objective": objective, "project_path": str(project_dir)},
         )
         reply = self.bus.wait_for_reply(
             agent_name="orchestrator",
@@ -128,18 +163,59 @@ class OrchestratorV10Async:
             timeout=self.settings.pm_timeout,
         )
         if reply is None:
-            raise TimeoutError("PM agent did not respond on time")
+            raise TimeoutError("PM agent no respondió a tiempo")
         payload = reply.payload
-        if payload.get("status") != "SUCCESS":
-            raise RuntimeError(payload.get("error", "PM agent returned an error"))
-        arch_data = payload["architecture"]
-        return Architecture(
-            proposed_modules=arch_data["proposed_modules"],
-            database_schema=arch_data["database_schema"],
-            technologies=arch_data["technologies"],
-            analysis=arch_data["analysis"],
-            reasoning=arch_data["reasoning"],
+        if payload.get("status") not in (None, "SUCCESS"):
+            raise RuntimeError(payload.get("error", "PM agent retornó un error"))
+        return payload
+
+    def _wait_for_dev_completion(self) -> Dict[str, Any]:
+        self.logger.info("Esperando a que Dev agent finalice el proyecto")
+        timeout = self.settings.dev_timeout
+        deadline = datetime.now().timestamp() + timeout
+        while datetime.now().timestamp() < deadline:
+            message = self.bus.receive("orchestrator", timeout=1.0)
+            if message is None:
+                continue
+            if message.sender == "dev_agent":
+                return message.payload
+        raise TimeoutError("Dev agent no finalizó dentro del tiempo esperado")
+
+    def _request_security_report(self, project_path: str) -> Dict[str, Any]:
+        payload = self.feedback_loop.last_security_payload
+        if payload.get("project_path") == project_path and payload:
+            return payload
+        message = self.bus.send(
+            sender="orchestrator",
+            recipient="security_agent",
+            payload={"project_path": project_path},
         )
+        reply = self.bus.wait_for_reply(
+            agent_name="orchestrator",
+            in_reply_to=message.message_id,
+            timeout=60.0,
+        )
+        if reply is None:
+            raise TimeoutError("Security agent no respondió")
+        return reply.payload
+
+    def _request_qa_report(self, project_path: str) -> Dict[str, Any]:
+        payload = self.feedback_loop.last_qa_payload
+        if payload.get("project_path") == project_path and payload:
+            return payload
+        message = self.bus.send(
+            sender="orchestrator",
+            recipient="qa_agent",
+            payload={"project_path": project_path},
+        )
+        reply = self.bus.wait_for_reply(
+            agent_name="orchestrator",
+            in_reply_to=message.message_id,
+            timeout=60.0,
+        )
+        if reply is None:
+            raise TimeoutError("QA agent no respondió")
+        return reply.payload
 
     def _persist_report(self, result: Dict[str, Any]) -> Path:
         reports_dir = get_runtime_root() / "reports"
@@ -147,16 +223,96 @@ class OrchestratorV10Async:
         report_path = reports_dir / f"report_{datetime.now():%Y%m%d_%H%M%S}.json"
         with report_path.open("w", encoding="utf-8") as handle:
             json.dump(result, handle, indent=2)
-        self.logger.success("Pipeline report stored", {"path": str(report_path)})
+        self.logger.success("Reporte generado", {"path": str(report_path)})
         return report_path
 
+    def _prepare_project_dir(self, project_name: str) -> Path:
+        slug = "_".join(project_name.lower().split())
+        base = self.workspace_root / slug
+        candidate = base
+        counter = 1
+        while candidate.exists():
+            counter += 1
+            candidate = self.workspace_root / f"{slug}_{counter}"
+        ensure_directory(candidate)
+        return candidate
+
+    # ------------------------------------------------------------------
+    # Workers auxiliares
+    # ------------------------------------------------------------------
+    def _security_worker(self) -> None:
+        agent = SecurityAgentV10()
+        while not self.stop_event.is_set():
+            message = self.bus.receive("security_agent", timeout=1.0)
+            if message is None:
+                continue
+            project_path = message.payload.get("project_path")
+            if not project_path:
+                self.bus.send(
+                    sender="security_agent",
+                    recipient=message.sender,
+                    payload={"error": "project_path requerido"},
+                    conversation_id=message.conversation_id,
+                    in_reply_to=message.message_id,
+                )
+                continue
+            result = agent.analyze(project_path)
+            payload = {
+                "project_path": project_path,
+                "score": result.score,
+                "issues": result.issues,
+                "critical_issues": result.critical_issues,
+                "warnings": result.warnings,
+                "passed": result.passed,
+            }
+            self.bus.send(
+                sender="security_agent",
+                recipient=message.sender,
+                payload=payload,
+                conversation_id=message.conversation_id,
+                in_reply_to=message.message_id,
+            )
+
+    def _qa_worker(self) -> None:
+        agent = QAAgentV10()
+        while not self.stop_event.is_set():
+            message = self.bus.receive("qa_agent", timeout=1.0)
+            if message is None:
+                continue
+            project_path = message.payload.get("project_path")
+            if not project_path:
+                self.bus.send(
+                    sender="qa_agent",
+                    recipient=message.sender,
+                    payload={"error": "project_path requerido"},
+                    conversation_id=message.conversation_id,
+                    in_reply_to=message.message_id,
+                )
+                continue
+            result = agent.analyze(project_path)
+            payload = {
+                "project_path": project_path,
+                "score": result.score,
+                "issues": result.issues,
+                "warnings": result.warnings,
+                "passed": result.passed,
+                "suggestions": result.issues + result.warnings,
+            }
+            self.bus.send(
+                sender="qa_agent",
+                recipient=message.sender,
+                payload=payload,
+                conversation_id=message.conversation_id,
+                in_reply_to=message.message_id,
+            )
+
     def _shutdown(self) -> None:
-        if self.pm_worker_stop is not None:
-            self.pm_worker_stop.set()
-            thread = getattr(self.pm_worker_stop, "thread", None)
-            if thread is not None:
-                thread.join(timeout=2)
-            self.logger.info("PM worker stopped")
+        self.stop_event.set()
+        self.pm_agent.stop()
+        self.dev_agent.stop()
+        self.security_thread.join(timeout=2)
+        self.qa_thread.join(timeout=2)
+        self.logger.info("Orquestador detenido")
 
 
 def main() -> int:
@@ -164,18 +320,20 @@ def main() -> int:
 
     parser = argparse.ArgumentParser(description="Run the V10 orchestrator asynchronously")
     parser.add_argument("objective", help="Project objective to be solved")
-    parser.add_argument("--project-name", help="Optional name for the generated project")
+    parser.add_argument("--project-name", help="Optional project name")
     parser.add_argument("--workspace", help="Workspace directory", default=None)
-    parser.add_argument("--pm-timeout", type=int, default=60, help="Timeout for PM responses")
-    parser.add_argument("--no-worker", action="store_true", help="Do not spawn the PM worker (for manual tests)")
+    parser.add_argument("--pm-timeout", type=int, default=60)
+    parser.add_argument("--dev-timeout", type=int, default=180)
+    parser.add_argument("--iterations", type=int, default=3)
 
     args = parser.parse_args()
 
-    workspace = Path(args.workspace) if args.workspace else None
+    workspace = Path(args.workspace) if args.workspace else get_runtime_root() / "projects"
     settings = OrchestratorSettings(
-        workspace_dir=workspace or get_runtime_root() / "workspace",
-        use_pm_worker=not args.no_worker,
+        workspace_dir=workspace,
         pm_timeout=args.pm_timeout,
+        dev_timeout=args.dev_timeout,
+        max_iterations=args.iterations,
     )
 
     orchestrator = OrchestratorV10Async(settings=settings)

--- a/control_center.py
+++ b/control_center.py
@@ -1,0 +1,209 @@
+"""Centro de control para lanzar y observar la colaboración entre agentes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from V10.core.orchestrator_v10_async import OrchestratorSettings, OrchestratorV10Async
+from V10.utils import get_runtime_root
+
+
+class StreamForwarder(threading.Thread):
+    """Reenvía líneas de un stream de proceso a la salida estándar."""
+
+    def __init__(self, stream, prefix: str) -> None:
+        super().__init__(daemon=True)
+        self.stream = stream
+        self.prefix = prefix
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:  # pragma: no cover - flujo interactivo
+        for line in iter(self.stream.readline, ""):
+            if self._stop_event.is_set():
+                break
+            if not line:
+                continue
+            text = line.rstrip()
+            if text:
+                print(f"[{self.prefix}] {text}")
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+class ControlCenter:
+    """Orquesta el servicio Claude y el orquestador en una sola herramienta."""
+
+    def __init__(
+        self,
+        objective: str,
+        *,
+        project_name: Optional[str] = None,
+        workspace: Optional[Path] = None,
+        start_service: bool = True,
+        open_browser: bool = False,
+        pm_timeout: int = 60,
+        dev_timeout: int = 180,
+        iterations: int = 3,
+    ) -> None:
+        self.objective = objective
+        self.project_name = project_name
+        self.workspace = workspace or get_runtime_root() / "projects"
+        self.start_service = start_service
+        self.open_browser = open_browser
+        self.pm_timeout = pm_timeout
+        self.dev_timeout = dev_timeout
+        self.iterations = iterations
+
+        self._service_process: Optional[subprocess.Popen[str]] = None
+        self._service_forwarder: Optional[StreamForwarder] = None
+
+    # ------------------------------------------------------------------
+    # Ejecución principal
+    # ------------------------------------------------------------------
+    def run(self) -> int:
+        print("🚀 Discovery Motor V10 - Centro de Control")
+        print("📌 Objetivo:", self.objective)
+
+        if self.start_service:
+            self._launch_service()
+        else:
+            print("⚠️  Asumiendo que el servicio Claude ya está ejecutándose en http://localhost:5000")
+
+        if self.open_browser:
+            self._open_browser()
+
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        settings = OrchestratorSettings(
+            workspace_dir=self.workspace,
+            pm_timeout=self.pm_timeout,
+            dev_timeout=self.dev_timeout,
+            max_iterations=self.iterations,
+        )
+
+        orchestrator = OrchestratorV10Async(settings=settings)
+        orchestrator.bus.logger.level = "INFO"
+        try:
+            result = orchestrator.execute(self.objective, project_name=self.project_name)
+            print("\n📄 Resultado final:")
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            status = result.get("status", "FAILED")
+            return 0 if status == "SUCCESS" else 1
+        except KeyboardInterrupt:  # pragma: no cover - modo interactivo
+            print("\n❌ Ejecución interrumpida por el usuario")
+            return 1
+        finally:
+            self.shutdown()
+
+    # ------------------------------------------------------------------
+    # Gestión del servicio Claude
+    # ------------------------------------------------------------------
+    def _launch_service(self) -> None:
+        print("▶️  Iniciando servicio Claude local...")
+        command = [sys.executable, "-m", "V10.claude_service"]
+        self._service_process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        assert self._service_process.stdout is not None
+        self._service_forwarder = StreamForwarder(self._service_process.stdout, "CLAUDE")
+        self._service_forwarder.start()
+        self._wait_for_service()
+
+    def _wait_for_service(self, timeout: int = 30) -> None:
+        deadline = time.time() + timeout
+        url = "http://localhost:5000/health"
+        while time.time() < deadline:
+            try:
+                response = requests.get(url, timeout=2)
+                if response.status_code == 200:
+                    print("✅ Servicio Claude listo en http://localhost:5000")
+                    return
+            except requests.RequestException:
+                time.sleep(1)
+        raise RuntimeError("No se pudo conectar con el servicio Claude en el tiempo esperado")
+
+    def _open_browser(self) -> None:
+        print("🌐 Abriendo interfaz web del servicio Claude...")
+        try:
+            import webbrowser
+
+            webbrowser.open("http://localhost:5000", new=2)
+        except Exception as exc:  # pragma: no cover - depende de OS
+            print(f"⚠️  No se pudo abrir el navegador automáticamente: {exc}")
+
+    # ------------------------------------------------------------------
+    # Limpieza
+    # ------------------------------------------------------------------
+    def shutdown(self) -> None:
+        if self._service_forwarder:
+            self._service_forwarder.stop()
+        if self._service_process and self._service_process.poll() is None:
+            print("⏹️  Deteniendo servicio Claude...")
+            if sys.platform != "win32":  # pragma: no cover - dependencia del entorno
+                self._service_process.send_signal(signal.SIGINT)
+                try:
+                    self._service_process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self._service_process.terminate()
+            else:
+                self._service_process.terminate()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Lanza el orquestador V10 y el servicio Claude desde una sola consola",
+    )
+    parser.add_argument("objective", help="Objetivo del proyecto a resolver")
+    parser.add_argument("--project-name", help="Nombre opcional del proyecto")
+    parser.add_argument(
+        "--workspace",
+        help="Directorio base para almacenar los proyectos generados",
+    )
+    parser.add_argument(
+        "--skip-service",
+        action="store_true",
+        help="No iniciar el servicio Claude (usar si ya está ejecutándose)",
+    )
+    parser.add_argument(
+        "--open-browser",
+        action="store_true",
+        help="Abrir la interfaz web del servicio Claude automáticamente",
+    )
+    parser.add_argument("--pm-timeout", type=int, default=60, help="Timeout del PM agent en segundos")
+    parser.add_argument("--dev-timeout", type=int, default=180, help="Timeout del Dev agent en segundos")
+    parser.add_argument("--iterations", type=int, default=3, help="Iteraciones máximas del feedback loop")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    workspace = Path(args.workspace).expanduser().resolve() if args.workspace else None
+    control = ControlCenter(
+        args.objective,
+        project_name=args.project_name,
+        workspace=workspace,
+        start_service=not args.skip_service,
+        open_browser=args.open_browser,
+        pm_timeout=args.pm_timeout,
+        dev_timeout=args.dev_timeout,
+        iterations=args.iterations,
+    )
+    return control.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI manual
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0.0
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- add a control center CLI that boots the Claude service, orchestrator and log forwarding from one terminal
- expose a health endpoint and disable the Flask reloader so the launcher can supervise the Claude service
- refresh the quickstart guide to document the single-command workflow for observing agent collaboration

## Testing
- python -m compileall V10 control_center.py

------
https://chatgpt.com/codex/tasks/task_b_68fbef8de5fc832c9edb6ae4c8d518f9